### PR TITLE
feat(ci): add ci workflow templates per framework

### DIFF
--- a/templates/flutter/.github/workflows/ci.yml
+++ b/templates/flutter/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+# CI Workflow — Flutter
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates code quality, tests, and build integrity.
+#
+# Steps:
+#   1. Static analysis (dart analyze — enforces analysis_options.yaml rules)
+#   2. Run unit and widget tests
+#   3. Flutter build (APK by default — change to ios/web as needed)
+#
+# Required status check name: "Analyze, Test & Build"
+
+name: Analyze, Test & Build
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Analyze, Test & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.x"
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Enforces rules from analysis_options.yaml
+      # --fatal-infos treats info-level issues as failures
+      - name: Analyze
+        run: dart analyze --fatal-infos
+
+      - name: Run tests
+        run: flutter test
+
+      # Build APK to verify compilation succeeds
+      # Change to `flutter build ios --no-codesign` or `flutter build web` as needed
+      - name: Build
+        run: flutter build apk --release

--- a/templates/nextjs/.github/workflows/ci.yml
+++ b/templates/nextjs/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# CI Workflow — Next.js
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates type safety, code quality, and build integrity.
+#
+# Steps:
+#   1. TypeScript type checking (tsc --noEmit)
+#   2. ESLint linting with zero warning tolerance
+#   3. Next.js production build
+#
+# Required status check name: "Type Check, Lint & Build"
+
+name: Type Check, Lint & Build
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Type Check, Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0 --no-warn-ignored
+
+      - name: Build
+        run: npm run build

--- a/templates/react-native/.github/workflows/ci.yml
+++ b/templates/react-native/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# CI Workflow — React Native
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates type safety and code quality.
+#
+# Note: React Native does not produce a traditional "build" artifact in CI
+# without platform-specific tooling (Xcode, Gradle). This workflow focuses
+# on type checking and linting. For full builds, use EAS Build or Fastlane.
+#
+# Steps:
+#   1. TypeScript type checking (tsc --noEmit)
+#   2. ESLint linting with zero warning tolerance
+#
+# Required status check name: "Type Check & Lint"
+
+name: Type Check & Lint
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Type Check & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0 --no-warn-ignored

--- a/templates/react/.github/workflows/ci.yml
+++ b/templates/react/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# CI Workflow — React (Vite)
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates type safety, code quality, and build integrity.
+#
+# Steps:
+#   1. TypeScript type checking (tsc --noEmit)
+#   2. ESLint linting with zero warning tolerance
+#   3. Vite production build
+#
+# Required status check name: "Type Check, Lint & Build"
+
+name: Type Check, Lint & Build
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Type Check, Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0 --no-warn-ignored
+
+      - name: Build
+        run: npm run build

--- a/templates/vue/.github/workflows/ci.yml
+++ b/templates/vue/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# CI Workflow — Vue.js
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates type safety, code quality, and build integrity.
+#
+# Steps:
+#   1. TypeScript type checking via vue-tsc (Vue-aware TS compiler)
+#   2. ESLint linting with zero warning tolerance
+#   3. Vite production build
+#
+# Required status check name: "Type Check, Lint & Build"
+
+name: Type Check, Lint & Build
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Type Check, Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # vue-tsc is the Vue-aware TypeScript compiler
+      # It handles .vue single-file components that tsc cannot parse
+      - name: Type check
+        run: npx vue-tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0 --no-warn-ignored
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
- Add Next.js CI workflow (type check, lint, build)
- Add React/Vite CI workflow (type check, lint, build)
- Add React Native CI workflow (type check, lint — no native build)
- Add Vue.js CI workflow (vue-tsc, lint, build)
- Add Flutter CI workflow (analyze, test, build APK)
- All workflows trigger on PRs to develop/main/master with concurrency control

Closes #4