### PR TITLE
feat(workflow): add pr-title and branch-naming validation workflows

### DIFF
--- a/templates/common/.github/workflows/branch-naming.yml
+++ b/templates/common/.github/workflows/branch-naming.yml
@@ -1,0 +1,76 @@
+# Branch Naming Validation Workflow
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates that the PR source branch follows the naming convention.
+#
+# Expected format: {type}/{PREFIX}-{number}
+#   e.g., feat/ATLAS-09, fix/TEMPO-12, chore/BASE-01
+#
+# The project prefix is read from `.dev-kit.yml` at the repo root.
+# Skips validation for base branches (develop, main, master).
+#
+# Allowed types: feat, fix, hotfix, chore, docs, refactor, test
+#
+# Required status check name: "Validate Branch Name"
+
+name: Validate Branch Name
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - develop
+      - main
+      - master
+
+jobs:
+  validate:
+    name: Validate Branch Name
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read project prefix from .dev-kit.yml
+        id: config
+        run: |
+          # Extract the project-prefix value from .dev-kit.yml
+          PREFIX=$(grep '^project-prefix:' .dev-kit.yml | sed 's/project-prefix: *//' | tr -d '[:space:]')
+
+          if [ -z "$PREFIX" ]; then
+            echo "::error::Could not read project-prefix from .dev-kit.yml"
+            exit 1
+          fi
+
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "Project prefix: $PREFIX"
+
+      - name: Validate branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
+          PREFIX: ${{ steps.config.outputs.prefix }}
+        run: |
+          # Skip validation for base branches
+          if echo "$BRANCH" | grep -qE '^(develop|main|master)$'; then
+            echo "Base branch detected — skipping validation."
+            exit 0
+          fi
+
+          # Allowed branch types
+          TYPES="feat|fix|hotfix|chore|docs|refactor|test"
+
+          # Pattern: type/PREFIX-number (e.g., feat/ATLAS-09)
+          PATTERN="^($TYPES)/${PREFIX}-[0-9]+$"
+
+          if echo "$BRANCH" | grep -qE "$PATTERN"; then
+            echo "Branch name is valid: $BRANCH"
+          else
+            echo "::error::Invalid branch name: $BRANCH"
+            echo ""
+            echo "Branch name must follow the format: {type}/${PREFIX}-{number}"
+            echo "  Example: feat/${PREFIX}-01, fix/${PREFIX}-12"
+            echo ""
+            echo "Allowed types: feat, fix, hotfix, chore, docs, refactor, test"
+            exit 1
+          fi

--- a/templates/common/.github/workflows/pr-title.yml
+++ b/templates/common/.github/workflows/pr-title.yml
@@ -1,0 +1,53 @@
+# PR Title Validation Workflow
+#
+# Runs on pull requests targeting develop or main branches.
+# Validates that the PR title follows Conventional Commits format.
+#
+# Valid formats:
+#   type: message            → e.g., "feat: add login page"
+#   type(scope): message     → e.g., "feat(auth): add login page"
+#
+# Allowed types: feat, fix, hotfix, chore, docs, style, refactor, test, build, ci, revert, perf
+# Scope: optional, must be kebab-case (lowercase, hyphens)
+#
+# Required status check name: "Validate PR Title"
+
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches:
+      - develop
+      - main
+      - master
+
+jobs:
+  validate:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Allowed commit/PR types (must match commitlint.config.mjs)
+          TYPES="feat|fix|hotfix|chore|docs|style|refactor|test|build|ci|revert|perf"
+
+          # Pattern: type(optional-kebab-scope): message
+          PATTERN="^($TYPES)(\([a-z0-9]+(-[a-z0-9]+)*\))?: .+"
+
+          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "::error::Invalid PR title: $PR_TITLE"
+            echo ""
+            echo "PR title must follow Conventional Commits format:"
+            echo "  type: message            → e.g., feat: add login page"
+            echo "  type(scope): message     → e.g., feat(auth): add login page"
+            echo ""
+            echo "Allowed types: feat, fix, hotfix, chore, docs, style, refactor, test, build, ci, revert, perf"
+            echo "Scope must be kebab-case (lowercase letters, numbers, hyphens)"
+            exit 1
+          fi


### PR DESCRIPTION
- Add pr-title.yml validating Conventional Commits format on PR titles
- Add branch-naming.yml validating {type}/{PREFIX}-{number} format
- Branch naming reads project prefix dynamically from .dev-kit.yml
- Both workflows trigger on PRs to develop/main/master

Closes #5