### PR TITLE
feat(gitignore): add framework-specific gitignore templates

### DIFF
--- a/templates/flutter/.gitignore
+++ b/templates/flutter/.gitignore
@@ -1,0 +1,62 @@
+# ─── Flutter / Dart ───────────────────────────────────────────────────────────────
+.dart_tool/
+.packages
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+
+# ─── Generated Code ─────────────────────────────────────────────────────────────
+*.g.dart
+*.freezed.dart
+*.mocks.dart
+.dart_tool/
+
+# ─── Environment Variables ───────────────────────────────────────────────────────
+.env
+.env.local
+.env.development
+.env.production
+
+# ─── Testing & Coverage ─────────────────────────────────────────────────────────
+coverage/
+
+# ─── Android ─────────────────────────────────────────────────────────────────────
+**/android/.gradle/
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# ─── iOS ─────────────────────────────────────────────────────────────────────────
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/Pods/
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# ─── Signing Keys ───────────────────────────────────────────────────────────────
+*.keystore
+!debug.keystore
+*.jks
+
+# ─── Logs ────────────────────────────────────────────────────────────────────────
+*.log
+
+# ─── OS Files ────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Editor / IDE ────────────────────────────────────────────────────────────────
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+*.swo
+
+# ─── Misc ────────────────────────────────────────────────────────────────────────
+.cache/

--- a/templates/nextjs/.gitignore
+++ b/templates/nextjs/.gitignore
@@ -1,0 +1,63 @@
+# ─── Dependencies ────────────────────────────────────────────────────────────────
+node_modules/
+.pnp/
+.pnp.js
+
+# ─── Next.js ─────────────────────────────────────────────────────────────────────
+.next/
+out/
+build/
+next-env.d.ts
+
+# ─── Environment Variables ───────────────────────────────────────────────────────
+# Keep .env.example as a reference; ignore everything else
+.env
+.env.local
+.env.development
+.env.development.local
+.env.test
+.env.test.local
+.env.production
+.env.production.local
+
+# ─── Testing & Coverage ─────────────────────────────────────────────────────────
+coverage/
+.nyc_output/
+
+# ─── TypeScript ──────────────────────────────────────────────────────────────────
+*.tsbuildinfo
+
+# ─── Caches ──────────────────────────────────────────────────────────────────────
+.eslintcache
+.stylelintcache
+.prettiercache
+
+# ─── Logs ────────────────────────────────────────────────────────────────────────
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# ─── OS Files ────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Editor / IDE ────────────────────────────────────────────────────────────────
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+*.swo
+
+# ─── Deployment ──────────────────────────────────────────────────────────────────
+.vercel/
+
+# ─── Misc ────────────────────────────────────────────────────────────────────────
+*.tgz
+.cache/
+*.pem
+
+# ─── Generated Code ─────────────────────────────────────────────────────────────
+# Prisma client (if using Prisma ORM)
+src/generated/

--- a/templates/react-native/.gitignore
+++ b/templates/react-native/.gitignore
@@ -1,0 +1,75 @@
+# ─── Dependencies ────────────────────────────────────────────────────────────────
+node_modules/
+.pnp/
+.pnp.js
+
+# ─── Build Output ────────────────────────────────────────────────────────────────
+# Android
+android/app/build/
+android/.gradle/
+android/build/
+
+# iOS
+ios/build/
+ios/Pods/
+ios/DerivedData/
+
+# Metro bundler
+*.jsbundle
+
+# ─── Environment Variables ───────────────────────────────────────────────────────
+.env
+.env.local
+.env.development
+.env.development.local
+.env.test
+.env.test.local
+.env.production
+.env.production.local
+
+# ─── Testing & Coverage ─────────────────────────────────────────────────────────
+coverage/
+.nyc_output/
+
+# ─── TypeScript ──────────────────────────────────────────────────────────────────
+*.tsbuildinfo
+
+# ─── Caches ──────────────────────────────────────────────────────────────────────
+.eslintcache
+.stylelintcache
+.prettiercache
+
+# ─── React Native / Expo ─────────────────────────────────────────────────────────
+.expo/
+*.hprof
+
+# ─── CocoaPods (iOS) ─────────────────────────────────────────────────────────────
+ios/Podfile.lock
+
+# ─── Logs ────────────────────────────────────────────────────────────────────────
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# ─── OS Files ────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Editor / IDE ────────────────────────────────────────────────────────────────
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+*.swo
+
+# ─── Signing Keys ───────────────────────────────────────────────────────────────
+*.keystore
+!debug.keystore
+*.jks
+*.pem
+
+# ─── Misc ────────────────────────────────────────────────────────────────────────
+*.tgz
+.cache/

--- a/templates/react/.gitignore
+++ b/templates/react/.gitignore
@@ -1,0 +1,53 @@
+# ─── Dependencies ────────────────────────────────────────────────────────────────
+node_modules/
+.pnp/
+.pnp.js
+
+# ─── Build Output ────────────────────────────────────────────────────────────────
+dist/
+build/
+
+# ─── Environment Variables ───────────────────────────────────────────────────────
+.env
+.env.local
+.env.development
+.env.development.local
+.env.test
+.env.test.local
+.env.production
+.env.production.local
+
+# ─── Testing & Coverage ─────────────────────────────────────────────────────────
+coverage/
+.nyc_output/
+
+# ─── TypeScript ──────────────────────────────────────────────────────────────────
+*.tsbuildinfo
+
+# ─── Caches ──────────────────────────────────────────────────────────────────────
+.eslintcache
+.stylelintcache
+.prettiercache
+
+# ─── Logs ────────────────────────────────────────────────────────────────────────
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# ─── OS Files ────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Editor / IDE ────────────────────────────────────────────────────────────────
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+*.swo
+
+# ─── Misc ────────────────────────────────────────────────────────────────────────
+*.tgz
+.cache/
+*.pem

--- a/templates/vue/.gitignore
+++ b/templates/vue/.gitignore
@@ -1,0 +1,53 @@
+# ─── Dependencies ────────────────────────────────────────────────────────────────
+node_modules/
+.pnp/
+.pnp.js
+
+# ─── Build Output ────────────────────────────────────────────────────────────────
+dist/
+build/
+
+# ─── Environment Variables ───────────────────────────────────────────────────────
+.env
+.env.local
+.env.development
+.env.development.local
+.env.test
+.env.test.local
+.env.production
+.env.production.local
+
+# ─── Testing & Coverage ─────────────────────────────────────────────────────────
+coverage/
+.nyc_output/
+
+# ─── TypeScript ──────────────────────────────────────────────────────────────────
+*.tsbuildinfo
+
+# ─── Caches ──────────────────────────────────────────────────────────────────────
+.eslintcache
+.stylelintcache
+.prettiercache
+
+# ─── Logs ────────────────────────────────────────────────────────────────────────
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# ─── OS Files ────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Editor / IDE ────────────────────────────────────────────────────────────────
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+*.swo
+
+# ─── Misc ────────────────────────────────────────────────────────────────────────
+*.tgz
+.cache/
+*.pem


### PR DESCRIPTION
- Add Next.js .gitignore (next build, vercel, prisma generated)
- Add React/Vite .gitignore (dist, build output)
- Add React Native .gitignore (android/ios builds, expo, keystores)
- Add Vue.js .gitignore (dist, build output)
- Add Flutter .gitignore (dart_tool, generated code, android/ios artifacts)
- All templates share common patterns for env, OS, editor, logs, coverage

Closes #10