### PR TITLE
feat(lint): add framework-specific linting configs

### DIFF
--- a/templates/flutter/analysis_options.yaml
+++ b/templates/flutter/analysis_options.yaml
@@ -1,0 +1,62 @@
+# Flutter/Dart Analysis Options
+#
+# Static analysis configuration for Dart code.
+# Enforced by `dart analyze` in CI and pre-commit hooks.
+#
+# Extends flutter_lints (recommended ruleset from the Flutter team).
+# Custom rules below are stricter overrides for code consistency.
+#
+# Requires: flutter_lints (add to dev_dependencies in pubspec.yaml)
+# See: https://dart.dev/tools/analysis
+
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  # Treat these issue severities as errors in CI (dart analyze --fatal-infos)
+  errors:
+    missing_return: error
+    dead_code: warning
+    unused_import: warning
+    unused_local_variable: warning
+
+  # Exclude generated code from analysis
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+    - "**/*.mocks.dart"
+    - "build/**"
+    - ".dart_tool/**"
+
+linter:
+  rules:
+    # ─── Style ───────────────────────────────────────────────────────────────────
+    # Enforce kebab-case for file names (matches project convention)
+    file_names: true
+
+    # Prefer single quotes for strings (Dart convention)
+    prefer_single_quotes: true
+
+    # Always use curly braces for control flow (even single-line)
+    always_use_package_imports: true
+    curly_braces_in_flow_control_structures: true
+
+    # ─── Safety ──────────────────────────────────────────────────────────────────
+    # Avoid using print() in production code (use a logger instead)
+    avoid_print: true
+
+    # Prefer const constructors for immutable widgets (performance)
+    prefer_const_constructors: true
+    prefer_const_declarations: true
+
+    # ─── Readability ─────────────────────────────────────────────────────────────
+    # Require type annotations on public APIs
+    always_declare_return_types: true
+
+    # Prefer final for local variables that are never reassigned
+    prefer_final_locals: true
+
+    # Use trailing commas for better diffs and formatting
+    require_trailing_commas: true
+
+    # Avoid unnecessary lambdas (use tear-offs instead)
+    unnecessary_lambdas: true

--- a/templates/nextjs/eslint.config.mjs
+++ b/templates/nextjs/eslint.config.mjs
@@ -1,0 +1,44 @@
+/**
+ * ESLint Configuration — Next.js
+ *
+ * Uses flat config format (ESLint v9+).
+ *
+ * Extends:
+ *   - next/core-web-vitals: Next.js recommended rules + Core Web Vitals checks
+ *   - next/typescript: TypeScript-aware rules for Next.js
+ *   - prettier: Disables formatting rules that conflict with Prettier
+ *
+ * Requires: eslint, eslint-config-next, eslint-config-prettier
+ * See: https://nextjs.org/docs/app/api-reference/config/eslint
+ */
+
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends(
+    "next/core-web-vitals",
+    "next/typescript",
+    "prettier"
+  ),
+  {
+    rules: {
+      // Allow anonymous default exports in config files (next.config.ts, etc.)
+      "import/no-anonymous-default-export": "off",
+    },
+  },
+  {
+    // Files and directories to ignore
+    ignores: [".next/**", "out/**", "build/**", "next-env.d.ts"],
+  },
+];
+
+export default eslintConfig;

--- a/templates/react-native/eslint.config.mjs
+++ b/templates/react-native/eslint.config.mjs
@@ -1,0 +1,58 @@
+/**
+ * ESLint Configuration — React Native
+ *
+ * Uses flat config format (ESLint v9+).
+ *
+ * Extends:
+ *   - eslint/recommended: Core ESLint rules
+ *   - typescript-eslint: TypeScript-aware linting
+ *   - react-hooks: Enforces Rules of Hooks
+ *   - react/jsx-runtime: Supports the new JSX transform
+ *   - prettier: Disables formatting rules that conflict with Prettier
+ *
+ * Note: React Native does not use a bundler like Vite, so no build-specific
+ * ignores are needed. Metro bundler output is not typically in the project root.
+ *
+ * Requires: eslint, typescript-eslint, eslint-plugin-react-hooks,
+ *           eslint-plugin-react, eslint-config-prettier
+ */
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import react from "eslint-plugin-react";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  // Core ESLint recommended rules
+  js.configs.recommended,
+
+  // TypeScript recommended rules
+  ...tseslint.configs.recommended,
+
+  // React JSX runtime support
+  {
+    ...react.configs.flat["jsx-runtime"],
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
+
+  // React Hooks rules
+  {
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: reactHooks.configs.recommended.rules,
+  },
+
+  // Prettier — disables rules that conflict with formatting
+  prettier,
+
+  // Files and directories to ignore
+  {
+    ignores: ["android/**", "ios/**", ".expo/**"],
+  }
+);

--- a/templates/react/eslint.config.mjs
+++ b/templates/react/eslint.config.mjs
@@ -1,0 +1,56 @@
+/**
+ * ESLint Configuration — React (Vite)
+ *
+ * Uses flat config format (ESLint v9+).
+ *
+ * Extends:
+ *   - eslint/recommended: Core ESLint rules
+ *   - typescript-eslint: TypeScript-aware linting
+ *   - react-hooks: Enforces Rules of Hooks
+ *   - react/jsx-runtime: Supports the new JSX transform (no need to import React)
+ *   - prettier: Disables formatting rules that conflict with Prettier
+ *
+ * Requires: eslint, typescript-eslint, eslint-plugin-react-hooks,
+ *           eslint-plugin-react, eslint-config-prettier
+ * See: https://eslint.org/docs/latest/use/configure/configuration-files
+ */
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import react from "eslint-plugin-react";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  // Core ESLint recommended rules
+  js.configs.recommended,
+
+  // TypeScript recommended rules
+  ...tseslint.configs.recommended,
+
+  // React JSX runtime support (no need to import React in every file)
+  {
+    ...react.configs.flat["jsx-runtime"],
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
+
+  // React Hooks rules (enforces Rules of Hooks)
+  {
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: reactHooks.configs.recommended.rules,
+  },
+
+  // Prettier — disables rules that conflict with formatting
+  prettier,
+
+  // Files and directories to ignore
+  {
+    ignores: ["dist/**", "build/**"],
+  }
+);

--- a/templates/vue/eslint.config.mjs
+++ b/templates/vue/eslint.config.mjs
@@ -1,0 +1,55 @@
+/**
+ * ESLint Configuration — Vue.js
+ *
+ * Uses flat config format (ESLint v9+).
+ *
+ * Extends:
+ *   - eslint/recommended: Core ESLint rules
+ *   - typescript-eslint: TypeScript-aware linting
+ *   - vue/vue3-recommended: Vue 3 recommended rules (includes essential + strongly-recommended)
+ *   - prettier: Disables formatting rules that conflict with Prettier
+ *
+ * Note: The vue-eslint-parser is required so ESLint can parse .vue single-file components.
+ * TypeScript inside <script lang="ts"> blocks is handled by typescript-eslint's parser.
+ *
+ * Requires: eslint, typescript-eslint, eslint-plugin-vue,
+ *           vue-eslint-parser, eslint-config-prettier
+ * See: https://eslint.vuejs.org
+ */
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import vue from "eslint-plugin-vue";
+import vueParser from "vue-eslint-parser";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  // Core ESLint recommended rules
+  js.configs.recommended,
+
+  // TypeScript recommended rules
+  ...tseslint.configs.recommended,
+
+  // Vue 3 recommended rules
+  ...vue.configs["flat/recommended"],
+
+  // Configure vue-eslint-parser to use typescript-eslint for <script lang="ts"> blocks
+  {
+    files: ["**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        sourceType: "module",
+      },
+    },
+  },
+
+  // Prettier — disables rules that conflict with formatting
+  prettier,
+
+  // Files and directories to ignore
+  {
+    ignores: ["dist/**", "build/**"],
+  }
+);


### PR DESCRIPTION
- Add Next.js ESLint config (core-web-vitals, typescript, prettier)
- Add React/Vite ESLint config (typescript-eslint, react-hooks, prettier)
- Add React Native ESLint config (same as React, ignores android/ios/.expo)
- Add Vue.js ESLint config (vue3-recommended, vue-eslint-parser, prettier)
- Add Flutter analysis_options.yaml (flutter_lints, kebab-case, strict rules)
- All JS/TS configs use ESLint v9 flat config format with prettier integration

Closes #11