### PR TITLE
feat(testing): add playwright e2e testing setup and ci integration

### DIFF
--- a/templates/common/.github/workflows/e2e.yml
+++ b/templates/common/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+# E2E Testing Workflow (Playwright)
+#
+# Runs end-to-end tests after CI passes.
+# Tests execute in real browsers (Chromium, Firefox, WebKit).
+#
+# This workflow runs separately from CI because E2E tests are slower
+# and depend on a running dev/build server.
+#
+# Artifacts: HTML report and traces are uploaded on failure for debugging.
+#
+# Required status check name: "E2E Tests"
+
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test --project=chromium
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload test traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/templates/nextjs/playwright.config.ts
+++ b/templates/nextjs/playwright.config.ts
@@ -1,0 +1,91 @@
+/**
+ * Playwright Configuration — Next.js
+ *
+ * End-to-end testing for Next.js applications.
+ * Tests run in real browsers (Chromium, Firefox, WebKit).
+ *
+ * Setup:
+ *   1. npm install --save-dev @playwright/test
+ *   2. npx playwright install (downloads browser binaries)
+ *   3. Add to package.json scripts: "test:e2e": "playwright test"
+ *
+ * Usage:
+ *   npm run test:e2e             — Run all E2E tests
+ *   npm run test:e2e -- --ui     — Open interactive UI mode
+ *   npm run test:e2e -- --debug  — Debug with browser DevTools
+ *
+ * See: https://playwright.dev
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  // Directory containing E2E test files
+  testDir: "./e2e",
+
+  // Match test files
+  testMatch: "**/*.spec.ts",
+
+  // Run tests in parallel across files
+  fullyParallel: true,
+
+  // Fail the build on CI if test.only is left in source code
+  forbidOnly: !!process.env.CI,
+
+  // Retry failed tests (more retries in CI for flakiness)
+  retries: process.env.CI ? 2 : 0,
+
+  // Limit parallel workers in CI to avoid resource contention
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter configuration
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
+
+  // Shared settings for all tests
+  use: {
+    // Base URL for relative navigation (e.g., page.goto("/dashboard"))
+    baseURL: "http://localhost:3000",
+
+    // Capture trace on first retry (for debugging failed tests in CI)
+    trace: "on-first-retry",
+
+    // Capture screenshot on failure
+    screenshot: "only-on-failure",
+  },
+
+  // Browser configurations to test against
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    // Mobile viewports (uncomment to enable)
+    // {
+    //   name: "mobile-chrome",
+    //   use: { ...devices["Pixel 7"] },
+    // },
+    // {
+    //   name: "mobile-safari",
+    //   use: { ...devices["iPhone 14"] },
+    // },
+  ],
+
+  // Start the Next.js dev server before running tests
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/templates/react-native/playwright.config.ts
+++ b/templates/react-native/playwright.config.ts
@@ -1,0 +1,60 @@
+/**
+ * Playwright Configuration — React Native (Web)
+ *
+ * End-to-end testing for React Native Web builds only.
+ * For native iOS/Android E2E testing, use Detox instead (out of scope for dev-kit).
+ *
+ * This config assumes you're using Expo with web support or React Native Web.
+ *
+ * Setup:
+ *   1. npm install --save-dev @playwright/test
+ *   2. npx playwright install
+ *   3. Add to package.json scripts: "test:e2e": "playwright test"
+ *
+ * See: https://playwright.dev
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
+
+  use: {
+    // Expo web default port
+    baseURL: "http://localhost:8081",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    // Mobile viewports (more relevant for React Native Web)
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 7"] },
+    },
+    {
+      name: "mobile-safari",
+      use: { ...devices["iPhone 14"] },
+    },
+  ],
+
+  webServer: {
+    command: "npx expo start --web",
+    url: "http://localhost:8081",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/templates/react/playwright.config.ts
+++ b/templates/react/playwright.config.ts
@@ -1,0 +1,56 @@
+/**
+ * Playwright Configuration — React (Vite)
+ *
+ * End-to-end testing for React/Vite applications.
+ *
+ * Setup:
+ *   1. npm install --save-dev @playwright/test
+ *   2. npx playwright install
+ *   3. Add to package.json scripts: "test:e2e": "playwright test"
+ *
+ * See: https://playwright.dev
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
+
+  use: {
+    // Vite dev server default port
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/templates/vue/playwright.config.ts
+++ b/templates/vue/playwright.config.ts
@@ -1,0 +1,55 @@
+/**
+ * Playwright Configuration — Vue.js
+ *
+ * End-to-end testing for Vue.js applications.
+ *
+ * Setup:
+ *   1. npm install --save-dev @playwright/test
+ *   2. npx playwright install
+ *   3. Add to package.json scripts: "test:e2e": "playwright test"
+ *
+ * See: https://playwright.dev
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
+
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});


### PR DESCRIPTION
- Add Next.js playwright.config.ts (localhost:3000, npm run dev)
- Add React/Vite playwright.config.ts (localhost:5173)
- Add React Native playwright.config.ts (web only, Expo, mobile viewports)
- Add Vue.js playwright.config.ts (localhost:5173)
- Add e2e.yml workflow (Chromium in CI, uploads report and traces on failure)
- Flutter uses built-in integration_test — no Playwright config needed
- All configs: parallel execution, retry on CI, trace on first retry

Closes #22