### PR TITLE
fix(workflow): skip dependabot prs from branch naming and pr title validation

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -20,6 +20,9 @@ jobs:
     name: Validate Branch Name
     runs-on: ubuntu-latest
 
+    # Skip Dependabot PRs — their branch names follow a different convention
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Validate branch name
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     name: Validate Templates
     runs-on: ubuntu-latest
 
+    # Skip Dependabot PRs — they only change dependency versions, not templates
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,6 +19,9 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
 
+    # Skip Dependabot PRs — their titles follow a different convention
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Check PR title format
         env:

--- a/templates/common/.github/workflows/branch-naming.yml
+++ b/templates/common/.github/workflows/branch-naming.yml
@@ -28,6 +28,9 @@ jobs:
     name: Validate Branch Name
     runs-on: ubuntu-latest
 
+    # Skip Dependabot PRs — their branch names follow a different convention
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/templates/common/.github/workflows/pr-title.yml
+++ b/templates/common/.github/workflows/pr-title.yml
@@ -27,6 +27,9 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
 
+    # Skip Dependabot PRs — their titles follow a different convention
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Check PR title format
         env:


### PR DESCRIPTION
- Add dependabot[bot] actor check to branch-naming, pr-title, and ci workflows
- Apply same fix to template workflows for downstream projects
- Prevents dependabot PRs from being blocked by convention checks

Closes #41